### PR TITLE
Change docker image for vulnerability fix.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.10
+FROM python:3.10-alpine3.18
+
+RUN apk  update --no-cache && apk upgrade --no-cache --available
 
 WORKDIR /code
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ local-setup: ## Sets up the local environment (e.g. install git hooks)
 
 .PHONY: build
 build: ## Builds the app
-	docker build .
+	docker build --no-cache -t  python-boilerplate .
 
 .PHONY: update
 update: ## Updates the app packages
@@ -20,7 +20,7 @@ update: ## Updates the app packages
 .PHONY: install
 install: ## Installs a new package in the app. ex: make install package=XXX
 	docker-compose run --rm --no-deps python-boilerplate poetry add $(package)
-	docker build .
+	docker build --no-cache -t  python-boilerplate .
 
 .PHONY: run
 run: ## Runs the app


### PR DESCRIPTION
It is proposed to change the base image and update on build to patch security vulnerabilities.

![image](https://github.com/pmareke/python-boilerplate/assets/1814307/ebe6b573-343e-40a5-b4b4-08e62b5672f3)


![image](https://github.com/pmareke/python-boilerplate/assets/1814307/b4956066-7428-4acf-a287-2c6c95b71b04)


The makefile is changed so that when building the image it rebuilds it completely in case there are patches and the python-boilerplate tag is added so that they are not created as none and can be used.

![image](https://github.com/pmareke/python-boilerplate/assets/1814307/893cc9fc-0043-403d-a9a4-6ede83298ad0)


We also gain in disk space. 249mb vs  1,19Gb

![image](https://github.com/pmareke/python-boilerplate/assets/1814307/e0336ffa-60aa-4eee-b6ba-f2eceb3c290b)
