### PR TITLE
Add pyproject.toml to rename-project command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,4 @@ rename-project: ## Rename project make rename name=new-name
 	sed -i 's/python-boilerplate/$(name)/' docker-compose.yaml
 	sed -i 's/python-boilerplate/$(name)/' Makefile
 	sed -i 's/python-boilerplate/$(name)/' .github/workflows/trivy.yml
+	sed -i 's/python-boilerplate/$(name)/' pyproject.toml

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,6 @@ pre-commit: check-format check-typing check-style test
 	
 .PHONY: rename-project
 rename-project: ## Rename project make rename name=new-name
-	sed -i 's/python-boilerplate/$(name)/' docker compose.yaml
+	sed -i 's/python-boilerplate/$(name)/' docker-compose.yaml
 	sed -i 's/python-boilerplate/$(name)/' Makefile
 	sed -i 's/python-boilerplate/$(name)/' .github/workflows/trivy.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "app"
+name = "python-boilerplate"
 version = "0.1.0"
 description = "This repository is a Python boilerplate to use as a fast starter point"
 authors = ["Pedro Lopez Mareque <pedro.lopez.mareque@gmail.com>"]


### PR DESCRIPTION
Rename the project name inside pyproject.toml
There is still an issue, which is that once you execute make rename-project you won't be able to do it again
The `sed` command won't find `python-boilerplate`  because it's been already replaced.